### PR TITLE
More Shadowlands abilities update (mainly offensive abilities)

### DIFF
--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -43,6 +43,14 @@ LCT_SpellData[48707] = {
 	duration = 5,
 	cooldown = 60
 }
+-- Anti-Magic Zone
+LCT_SpellData[51052] = {
+	class = "DEATHKNIGHT",
+	defensive = true,
+	duration = 10,
+	cooldown = 120
+}
+
 -- DK/mixed
 -- Death and Decay
 LCT_SpellData[43265] = {
@@ -69,14 +77,7 @@ LCT_SpellData[77606] = {
 	duration = 8,
 	cooldown = 25
 }
--- Anti-Magic Zone
-LCT_SpellData[51052] = {
-	class = "DEATHKNIGHT",
-	talent = true,
-	defensive = true,
-	duration = 10,
-	cooldown = 120
-}
+
 -- DK/mixed/talents
 -- Asphyxiate
 LCT_SpellData[108194] = {

--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -199,7 +199,7 @@ LCT_SpellData[51271] = {
 	specID = { SPEC_DK_FROST },
 	offensive = true,
 	defensive = true,
-	duration = 20,
+	duration = 12,
 	cooldown = 60
 }
 -- Empower Rune Weapon
@@ -239,9 +239,9 @@ LCT_SpellData[279302] = {
 	class = "DEATHKNIGHT",
 	specID = { SPEC_DK_FROST },
 	offensive = true,
-	talent = true,
 	duration = 10,
-	cooldown = 180
+	cooldown = 180,
+	opt_lower_cooldown = 90, -- Absolute Zero legendary, always all frost DKs play this
 }
 -- Blinding Sleet
 LCT_SpellData[207167] = {
@@ -249,13 +249,6 @@ LCT_SpellData[207167] = {
 	specID = { SPEC_DK_FROST },
 	talent = true,
 	cooldown = 60
-}
--- Chill Streak
-LCT_SpellData[207167] = {
-	class = "DEATHKNIGHT",
-	specID = { SPEC_DK_FROST },
-	talent = true,
-	cooldown = 45
 }
 -- Horn of Winter
 LCT_SpellData[57330] = {

--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -257,6 +257,13 @@ LCT_SpellData[57330] = {
 	talent = true,
 	cooldown = 45
 }
+-- Chill Streak	
+LCT_SpellData[305392] = {	
+	class = "DEATHKNIGHT",	
+	specID = { SPEC_DK_FROST },	
+	talent = true,	
+	cooldown = 45	
+}
 
 -- DK/Unholy
 -- Raise Dead

--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -241,7 +241,7 @@ LCT_SpellData[279302] = {
 	offensive = true,
 	duration = 10,
 	cooldown = 180,
-	opt_lower_cooldown = 90, -- Absolute Zero legendary, always all frost DKs play this
+	opt_lower_cooldown = 90, -- Absolute Zero legendary, almost all frost DKs play this
 }
 -- Blinding Sleet
 LCT_SpellData[207167] = {

--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -241,7 +241,7 @@ LCT_SpellData[279302] = {
 	offensive = true,
 	duration = 10,
 	cooldown = 180,
-	opt_lower_cooldown = 90, -- Absolute Zero legendary, almost all frost DKs play this
+	opt_lower_cooldown = 90, -- Absolute Zero legendary, almost all high level frost DKs play this. TODO: if the meta stays this way, make 90s cooldown a baseline.
 }
 -- Blinding Sleet
 LCT_SpellData[207167] = {

--- a/cooldowns_druid.lua
+++ b/cooldowns_druid.lua
@@ -206,6 +206,7 @@ LCT_SpellData[106951] = {
 LCT_SpellData[102543] = {
 	class = "DRUID",
 	specID = { SPEC_DRUID_FERAL },
+	talent = true,
 	offensive = true,
 	cooldown = 180,
 	duration = 30,

--- a/cooldowns_monk.lua
+++ b/cooldowns_monk.lua
@@ -305,7 +305,6 @@ LCT_SpellData[122470] = {
 	duration = 10,
 	cooldown = 90
 }
--- Mond/Windwalker/talents
 -- Rushing Jade Wind (WW)
 LCT_SpellData[261715] = {
 	class = "MONK",

--- a/cooldowns_monk.lua
+++ b/cooldowns_monk.lua
@@ -32,12 +32,20 @@ LCT_SpellData[119381] = {
 	class = "MONK",
 	stun = true,
 	cooldown = 60,
+	opt_lower_cooldown = 50, -- with Tiger Tail Sweep
 }
 -- Provoke
 LCT_SpellData[115546] = {
 	class = "MONK",
 	cooldown = 8
 }
+-- Touch of Death
+LCT_SpellData[322109] = {
+	class = "MONK",
+	offensive = true,
+	cooldown = 180,
+}
+
 -- Monk/mixed
 -- Detox
 LCT_SpellData[218164] = {
@@ -98,7 +106,7 @@ LCT_SpellData[116844] = {
 	class = "MONK",
 	talent = true,
 	defensive = true,
-	duration = 8,
+	duration = 5,
 	cooldown = 45,
 }
 -- Monk/mixed/talents
@@ -252,13 +260,6 @@ LCT_SpellData[202162] = {
 }
 
 -- Monk/Windwalker
--- Touch of Death
-LCT_SpellData[115080] = {
-	class = "MONK",
-	specID = { SPEC_MONK_WINDWALKER },
-	offensive = true,
-	cooldown = 120,
-}
 -- Storm, Earth, and Fire
 LCT_SpellData[137639] = {
 	class = "MONK",
@@ -331,7 +332,6 @@ LCT_SpellData[261947] = {
 LCT_SpellData[123904] = {
 	class = "MONK",
 	specID = { SPEC_MONK_WINDWALKER },
-	talent = true,
 	duration = 20,
 	cooldown = 120,
 }

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -28,7 +28,7 @@ LCT_SpellData[31884] = {
 	class = "PALADIN",
 	offensive = true,
 	defensive = true,
-	duration = 25,
+	duration = 20,
 	cooldown = 120,
   cooldown_starts_on_aura_duration = true,
 }

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -395,7 +395,6 @@ LCT_SpellData[343721] = {
 	class = "PALADIN",
 	specID = { SPEC_PALADIN_RETRIBUTION },
 	talent = true,
-	duration = 8,
 	cooldown = 60
 }
 

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -346,6 +346,13 @@ LCT_SpellData[184662] = {
 	duration = 15,
 	cooldown = 120
 }
+-- Wake of Ashes
+LCT_SpellData[255937] = {
+	class = "PALADIN",
+	specID = { SPEC_PALADIN_RETRIBUTION },
+	cooldown = 45
+}
+
 -- Paladin/Retribution/talents
 -- Eye for an eye
 LCT_SpellData[205191] = {
@@ -355,13 +362,6 @@ LCT_SpellData[205191] = {
 	defensive = true,
 	duration = 10,
 	cooldown = 60
-}
--- Wake of Ashes
-LCT_SpellData[255937] = {
-	class = "PALADIN",
-	specID = { SPEC_PALADIN_RETRIBUTION },
-	talent = true,
-	cooldown = 45
 }
 -- Blessing of Sanctuary
 LCT_SpellData[210256] = {
@@ -388,6 +388,14 @@ LCT_SpellData[247675] = {
 	class = "PALADIN",
 	specID = { SPEC_PALADIN_RETRIBUTION },
 	talent = true,
+	cooldown = 60
+}
+-- Final Reckoning
+LCT_SpellData[343721] = {
+	class = "PALADIN",
+	specID = { SPEC_PALADIN_RETRIBUTION },
+	talent = true,
+	duration = 8,
 	cooldown = 60
 }
 

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -70,11 +70,7 @@ LCT_SpellData[1022] = {
 	opt_charges = 2,
 	opt_charges_linked = { 1044, 6940 },
 	duration = 10,
-	cooldown = 300,
-	cooldown_overload = {
-		[SPEC_PALADIN_RETRIBUTION] = 180, -- ret
-		[SPEC_PALADIN_HOLY] = 240, -- holy
-	},
+	cooldown = 300
 }
 -- Rebuke
 LCT_SpellData[96231] = {

--- a/cooldowns_warrior.lua
+++ b/cooldowns_warrior.lua
@@ -139,7 +139,7 @@ LCT_SpellData[118038] = {
 	specID = { SPEC_WARRIOR_ARMS },
 	defensive = true,
 	duration = 8,
-	cooldown = 180
+	cooldown = 120
 }
 -- Colossus Smash
 LCT_SpellData[167105] = {


### PR DESCRIPTION
Updated the following:

- DK
1. Anti-Magic Zone is now baseline, not a talent
2. Pillar of Frost lasts 12 sec, not 20
3. Frostwyrm's Fury has optional lower CD of 1.5 min, due to Absolute Zero legendary
4. Fixed Chill Streak Spell ID

- Druid
Minor fix: Incarnation should have the condition talent = true

- Monk
1. Leg Sweep has optional lower CD of 50 sec, due to Tiger Tail Sweep talent
2. Touch of Death is now baseline, with 3 min CD
3. Ring of Peace duration is 5 sec, not 8 sec
4. Windwalker Xuen White Tiger is now spec baseline, not a talent

- Paladin
1. Avenging Wrath duration is 20 sec, not 25 sec
2. Add Final Reckoning talent for Ret
3. Wake of Ashes is now Ret baseline, not talent

- Warrior
Die by the Sword cooldown is now 2 min, down from 3 min
