### PR TITLE
Shadowlands abilities update

### DIFF
--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -34,7 +34,8 @@ LCT_SpellData[48792] = {
 	class = "DEATHKNIGHT",
 	defensive = true,
 	duration = 8,
-	cooldown = 180
+	cooldown = 180,
+	opt_lower_cooldown = 148 -- With conduit cooldown reduction, season 1 max is 32 sec, update in future seasons
 }
 -- Anti-Magic Shell
 LCT_SpellData[48707] = {

--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -50,6 +50,13 @@ LCT_SpellData[51052] = {
 	duration = 10,
 	cooldown = 120
 }
+-- Lichborne
+LCT_SpellData[49039] = {
+	class = "DEATHKNIGHT",
+	defensive = true,
+	duration = 10,
+	cooldown = 120
+}
 
 -- DK/mixed
 -- Death and Decay

--- a/cooldowns_hunter.lua
+++ b/cooldowns_hunter.lua
@@ -297,15 +297,17 @@ LCT_SpellData[213691] = {
 	cc = true,
 	cooldown = 30
 }
--- Hunter/Marksmanship/talents
 -- Trueshot
 LCT_SpellData[288613] = {
 	class = "HUNTER",
 	specID = { SPEC_HUNTER_MM },
-	talent = true,
 	offensive = true,
+	duration = 15,
+	opt_lower_cooldown = 100,
 	cooldown = 120
 }
+
+-- Hunter/Marksmanship/talents
 -- Piercing Shot
 LCT_SpellData[198670] = {
 	class = "HUNTER",

--- a/cooldowns_priest.lua
+++ b/cooldowns_priest.lua
@@ -346,7 +346,8 @@ LCT_SpellData[47585] = {
 	specID = { SPEC_PRIEST_SHADOW },
 	defensive = true,
 	duration = 6,
-	cooldown = 120
+	cooldown = 120,
+	opt_lower_cooldown = 90
 }
 -- Vampiric Embrace
 LCT_SpellData[15286] = {

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -259,7 +259,7 @@ LCT_SpellData[204366] = {
 	cooldown = 45,
 }
 -- Shamanism (Alliance)
-LCT_SpellData[32182] = {
+LCT_SpellData[204362] = {
 	class = "SHAMAN",
 	specID = { SPEC_SHAMAN_ENHANCEMENT },
 	talent = true,
@@ -267,7 +267,7 @@ LCT_SpellData[32182] = {
 	duration = 10
 }
 -- Shamanism (Horde)
-LCT_SpellData[2825] = {
+LCT_SpellData[204361] = {
 	class = "SHAMAN",
 	specID = { SPEC_SHAMAN_ENHANCEMENT },
 	talent = true,

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -258,8 +258,16 @@ LCT_SpellData[204366] = {
 	talent = true,
 	cooldown = 45,
 }
--- Shamanism
-LCT_SpellData[193876] = {
+-- Shamanism (Alliance)
+LCT_SpellData[32182] = {
+	class = "SHAMAN",
+	specID = { SPEC_SHAMAN_ENHANCEMENT },
+	talent = true,
+	cooldown = 60,
+	duration = 10
+}
+-- Shamanism (Horde)
+LCT_SpellData[2825] = {
 	class = "SHAMAN",
 	specID = { SPEC_SHAMAN_ENHANCEMENT },
 	talent = true,

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -273,6 +273,14 @@ LCT_SpellData[188089] = {
 	specID = { SPEC_SHAMAN_ENHANCEMENT },
 	cooldown = 20,
 }
+-- Doom Winds
+LCT_SpellData[335902] = {
+	class = "SHAMAN",
+	talent = true,
+	specID = { SPEC_SHAMAN_ENHANCEMENT },
+	duration = 12,
+	cooldown = 60,
+}
 
 -- Shaman/Restoration
 -- Healing Stream Totem

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -258,8 +258,8 @@ LCT_SpellData[204366] = {
 	talent = true,
 	cooldown = 45,
 }
--- Bloodlust
-LCT_SpellData[2825] = {
+-- Shamanism
+LCT_SpellData[193876] = {
 	class = "SHAMAN",
 	specID = { SPEC_SHAMAN_ENHANCEMENT },
 	talent = true,

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -282,7 +282,7 @@ LCT_SpellData[188089] = {
 	cooldown = 20,
 }
 -- Doom Winds
-LCT_SpellData[335902] = {
+LCT_SpellData[335903] = {
 	class = "SHAMAN",
 	talent = true,
 	specID = { SPEC_SHAMAN_ENHANCEMENT },


### PR DESCRIPTION
Update the following abilities:
DK:
- Ice Bound Fortitude has optional lower cooldown due to conduit, set to season 1 max cd reduction 32 sec
- Add new Lichborne baseline which gives immune to fear, charm and sleep, 2 min cd
Hunter:
- Trueshot is now baseline, with optional lower cooldown due to talent
Shaman:
- Add Doom Winds legendary
- Bloodlust and Heroism have different spell ID for alliance and horde
Priest:
- Dispersion has optional 90 sec cooldown (down from 120) due to talent (not making 90 sec baseline because there are still a lot of matchups they play without that talent)