### PR TITLE
fix undead racial bug

### DIFF
--- a/library.lua
+++ b/library.lua
@@ -846,20 +846,19 @@ function events:ARENA_OPPONENT_UPDATE(event, unit, unitEvent)
 end
 
 function events:ARENA_COOLDOWNS_UPDATE(event, unit)
-	if string.sub(unit, 1, 5) ~= "arena" then return end
-  --print("unit = " .. unit .. ", spellId = " .. (spellID or "nil") .. ", start = " .. (startTime or "nil") .. ", duration = " .. (duration or "nil"))
+
+	if string.sub(unit, 1, 5) ~= "arena" then 
+		return 
+	end
 
 	local spellID, startTime, duration = C_PvP.GetArenaCrowdControlInfo(unit)
-  if not spellID then
-    C_PvP.RequestCrowdControlSpell(unit)
-    return
-  end
-  lib:DetectSpell(unit, spellID)
-	lib.callbacks:Fire("LCT_CooldownDetected", unit, spellID)
-  --print("unit = " .. unit .. ", spellId = " .. (spellID or "nil") .. ", start = " .. (startTime or "nil") .. ", duration = " .. (duration or "nil"))
-  if not spellID then return end
 
-  if not startTime or not duration then
-    return
-  end
+  	if not spellID then
+    	C_PvP.RequestCrowdControlSpell(unit)
+    	return
+  	end
+
+  	lib:DetectSpell(unit, spellID)
+  	lib.callbacks:Fire("LCT_CooldownDetected", unit, spellID)
+  	--print("unit = " .. unit .. ", spellId = " .. (spellID or "nil") .. ", start = " .. (startTime or "nil") .. ", duration = " .. (duration or "nil"))
 end

--- a/library.lua
+++ b/library.lua
@@ -847,18 +847,18 @@ end
 
 function events:ARENA_COOLDOWNS_UPDATE(event, unit)
 
-	if string.sub(unit, 1, 5) ~= "arena" then 
-		return 
-	end
+  if string.sub(unit, 1, 5) ~= "arena" then 
+    return 
+  end
 
-	local spellID, startTime, duration = C_PvP.GetArenaCrowdControlInfo(unit)
+  local spellID, startTime, duration = C_PvP.GetArenaCrowdControlInfo(unit)
 
-  	if not spellID then
-    	C_PvP.RequestCrowdControlSpell(unit)
-    	return
-  	end
+  if not spellID then
+    C_PvP.RequestCrowdControlSpell(unit)
+    return
+  end
 
-  	lib:DetectSpell(unit, spellID)
-  	lib.callbacks:Fire("LCT_CooldownDetected", unit, spellID)
-  	--print("unit = " .. unit .. ", spellId = " .. (spellID or "nil") .. ", start = " .. (startTime or "nil") .. ", duration = " .. (duration or "nil"))
+  lib:DetectSpell(unit, spellID)
+  lib.callbacks:Fire("LCT_CooldownDetected", unit, spellID)
+  --print("unit = " .. unit .. ", spellId = " .. (spellID or "nil") .. ", start = " .. (startTime or "nil") .. ", duration = " .. (duration or "nil"))
 end

--- a/library.lua
+++ b/library.lua
@@ -862,5 +862,4 @@ function events:ARENA_COOLDOWNS_UPDATE(event, unit)
   if not startTime or not duration then
     return
   end
-  CooldownEvent("UNIT_SPELLCAST_SUCCEEDED", unit, spellID, duration / 1000, startTime / 1000)
 end


### PR DESCRIPTION
OK, spent some time in a war game testing this.

I think what the source of the bug is here:
- Game throws ARENA_COOLDOWNS_UPDATE  with the spellID of Medallion when WOTF is cast. 
- Code is currently passing this to `CooldownEvent()` with the ID of Medallion so it goes on 2min CD. 
- There is a bug somewhere underneath the covers here in the way we pass Medallion (the ARENA_COOLDOWNS_UPDATE  tells us it's 30s cd, but we end up thinking its a 2m cd). 
- I didn't find the bug here, but my hope is my fix is good and I don't need to. 

I added some prints to prove:
```
[12:49:25] enter acu function
[12:49:25] ARENA_COOLDOWNS_UPDATE
[12:49:25] unit = arena1, spellId = 336126, start = 2564183454, duration = 30000
```

So I think what is happening is the ARENA_COOLDOWNS_UPDATE function is trying to tell us that the WOTF cast should put Medallion on a 30000ms CD. But I suspect the code reads that as "Medallion has been cast, we know the CD is 2 mins so track that" - even though the event here is clearly telling us otherwise. 

Basically there is a clash between blizzard's event now trying to do something that GEX already handles. As such we can stop sending the cooldown event. 

I'm going to play some games today with this change to test it, feels like there is a risk I've broken some function that I wasn't testing in my game - but I think the only two racial interactions with trinket are human and undead so hopefully I'll get plenty testing. 

Opening the pull request incase you have comments meanwhile. I'll report back with the testing. 

