### PR TITLE
Update mage cauterize and alter time, and some other CC abilities

### DIFF
--- a/cooldowns_druid.lua
+++ b/cooldowns_druid.lua
@@ -97,7 +97,6 @@ LCT_SpellData[61336] = {
 	defensive = true,
 	cooldown = 180,
 	duration = 6,
-	charges = 2
 }
 -- Druid/talents/mixed
 -- Thorns

--- a/cooldowns_mage.lua
+++ b/cooldowns_mage.lua
@@ -62,6 +62,7 @@ LCT_SpellData[80353] = {
 -- Mage/mixed
 -- Alter Time (fire & frost)
 LCT_SpellData[108978] = 110909
+LCT_SpellData[127140] = 110909
 LCT_SpellData[110909] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE, SPEC_MAGE_FROST },
@@ -71,6 +72,7 @@ LCT_SpellData[110909] = {
 }
 -- Alter Time (arcane)
 LCT_SpellData[342245] = 342246
+LCT_SpellData[342247] = 342246
 LCT_SpellData[342246] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_ARCANE },

--- a/cooldowns_mage.lua
+++ b/cooldowns_mage.lua
@@ -61,23 +61,19 @@ LCT_SpellData[80353] = {
 
 -- Mage/mixed
 -- Alter Time (fire & frost)
-LCT_SpellData[108978] = 110909
-LCT_SpellData[127140] = 110909
-LCT_SpellData[110909] = {
+LCT_SpellData[108978] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE, SPEC_MAGE_FROST },
 	defensive = true,
-	cooldown_starts_on_aura_fade = true,
+	duration = 10,
 	cooldown = 60
 }
 -- Alter Time (arcane)
-LCT_SpellData[342245] = 342246
-LCT_SpellData[342247] = 342246
-LCT_SpellData[342246] = {
+LCT_SpellData[342245] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_ARCANE },
 	defensive = true,
-	cooldown_starts_on_aura_fade = true,
+	duration = 10,
 	cooldown = 60,
 	opt_lower_cooldown = 30, -- with 342249 Master of Time
 }
@@ -240,8 +236,7 @@ LCT_SpellData[108853] = {
 	cooldown = 12
 }
 -- Cauterize
-LCT_SpellData[87024] = 87023
-LCT_SpellData[87023] = {
+LCT_SpellData[86949] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE },
 	defensive = true,

--- a/cooldowns_mage.lua
+++ b/cooldowns_mage.lua
@@ -62,7 +62,7 @@ LCT_SpellData[80353] = {
 
 -- Mage/mixed
 -- Alter Time (fire & frost)
-LCT_SpellData[127140] = {
+LCT_SpellData[110909] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE, SPEC_MAGE_FROST },
 	defensive = true,
@@ -70,7 +70,7 @@ LCT_SpellData[127140] = {
 	cooldown = 60
 }
 -- Alter Time (arcane)
-LCT_SpellData[342247] = {
+LCT_SpellData[342246] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_ARCANE },
 	defensive = true,

--- a/cooldowns_mage.lua
+++ b/cooldowns_mage.lua
@@ -49,7 +49,6 @@ LCT_SpellData[45438] = {
 LCT_SpellData[55342] = {
 	class = "MAGE",
 	offensive = true,
-	talent = true,
 	cooldown = 120
 }
 -- Time Warp
@@ -62,6 +61,7 @@ LCT_SpellData[80353] = {
 
 -- Mage/mixed
 -- Alter Time (fire & frost)
+LCT_SpellData[108978] = 110909
 LCT_SpellData[110909] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE, SPEC_MAGE_FROST },
@@ -70,6 +70,7 @@ LCT_SpellData[110909] = {
 	cooldown = 60
 }
 -- Alter Time (arcane)
+LCT_SpellData[342245] = 342246
 LCT_SpellData[342246] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_ARCANE },
@@ -237,6 +238,7 @@ LCT_SpellData[108853] = {
 	cooldown = 12
 }
 -- Cauterize
+LCT_SpellData[87024] = 87023
 LCT_SpellData[87023] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE },

--- a/cooldowns_mage.lua
+++ b/cooldowns_mage.lua
@@ -62,19 +62,19 @@ LCT_SpellData[80353] = {
 
 -- Mage/mixed
 -- Alter Time (fire & frost)
-LCT_SpellData[108978] = {
+LCT_SpellData[127140] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE, SPEC_MAGE_FROST },
 	defensive = true,
-	duration = 10,
+	cooldown_starts_on_aura_fade = true,
 	cooldown = 60
 }
 -- Alter Time (arcane)
-LCT_SpellData[342245] = {
+LCT_SpellData[342247] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_ARCANE },
 	defensive = true,
-	duration = 10,
+	cooldown_starts_on_aura_fade = true,
 	cooldown = 60,
 	opt_lower_cooldown = 30, -- with 342249 Master of Time
 }
@@ -237,7 +237,7 @@ LCT_SpellData[108853] = {
 	cooldown = 12
 }
 -- Cauterize
-LCT_SpellData[86949] = {
+LCT_SpellData[87023] = {
 	class = "MAGE",
 	specID = { SPEC_MAGE_FIRE },
 	defensive = true,

--- a/cooldowns_priest.lua
+++ b/cooldowns_priest.lua
@@ -73,6 +73,9 @@ LCT_SpellData[8122] = {
 	class = "PRIEST",
 	cc = true,
 	cooldown = 30, -- Technically 60, but most priests play with -30s talent.
+	cooldown_overload = {
+		[SPEC_PRIEST_SHADOW] = 60, -- Shadow priest doesn't have the -30s talent
+	}
 }
 -- Priest/talents
 -- Thoughtsteal

--- a/cooldowns_rogue.lua
+++ b/cooldowns_rogue.lua
@@ -68,7 +68,6 @@ LCT_SpellData[2094] = {
 -- Kidney Shot
 LCT_SpellData[408] = {
 	class = "ROGUE",
-	specID = { SPEC_ROGUE_ASSA, SPEC_ROGUE_SUB },
 	stun = true,
 	cooldown = 20
 }

--- a/cooldowns_warlock.lua
+++ b/cooldowns_warlock.lua
@@ -95,6 +95,12 @@ LCT_SpellData[108503] = {
 	talent = true,
 	cooldown = 30
 }
+-- Howl of Terror
+LCT_SpellData[5484] = {
+	class = "WARLOCK",
+	talent = true,
+	cooldown = 40
+}
 
 -- Warlock/Affliction
 -- Summon Darkglare


### PR DESCRIPTION
Alter time needs to use the spell id of the buffs, and cooldown starts when the buff fades

Cauterize needs to use the spell id of the debuff.

Tested both in skirmishes