### PR TITLE
Shadowlands ability update

### DIFF
--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -304,6 +304,13 @@ LCT_SpellData[63560] = {
 	duration = 15,
 	cooldown = 60
 }
+-- Apocalypse
+LCT_SpellData[275699] = {
+	class = "DEATHKNIGHT",
+	specID = { SPEC_DK_UNHOLY },
+	offensive = true,
+	cooldown = 75
+}
 -- DK/Unholy/talents
 -- Raise Abomination
 LCT_SpellData[288853] = {

--- a/cooldowns_druid.lua
+++ b/cooldowns_druid.lua
@@ -251,6 +251,12 @@ LCT_SpellData[99] = {
 	specID = { SPEC_DRUID_GUARDIAN },
 	cooldown = 30
 }
+LCT_SpellData[99] = {
+	class = "DRUID",
+	specID = { SPEC_DRUID_BALANCE, SPEC_DRUID_FERAL, SPEC_DRUID_RESTO },
+	talent = true, -- with Guardian affinity
+	cooldown = 30
+}
 -- Frenzied Regeneration
 LCT_SpellData[22842] = {
 	class = "DRUID",

--- a/cooldowns_druid.lua
+++ b/cooldowns_druid.lua
@@ -248,14 +248,8 @@ LCT_SpellData[202028] = {
 -- Incapacitating Roar
 LCT_SpellData[99] = {
 	class = "DRUID",
-	specID = { SPEC_DRUID_GUARDIAN },
-	cooldown = 30
-}
--- Incapacitating Roar
-LCT_SpellData[99] = {
-	class = "DRUID",
-	specID = { SPEC_DRUID_BALANCE, SPEC_DRUID_FERAL, SPEC_DRUID_RESTO },
-	talent = true, -- with Guardian affinity
+	specID = { SPEC_DRUID_GUARDIAN, SPEC_DRUID_BALANCE, SPEC_DRUID_FERAL, SPEC_DRUID_RESTO },
+	talent = true, -- Baseline for Guardian, but talent for other specs
 	cooldown = 30
 }
 -- Frenzied Regeneration

--- a/cooldowns_druid.lua
+++ b/cooldowns_druid.lua
@@ -245,12 +245,13 @@ LCT_SpellData[202028] = {
 }
 
 -- Druid/Guardian
--- Disorienting Roar
+-- Incapacitating Roar
 LCT_SpellData[99] = {
 	class = "DRUID",
 	specID = { SPEC_DRUID_GUARDIAN },
 	cooldown = 30
 }
+-- Incapacitating Roar
 LCT_SpellData[99] = {
 	class = "DRUID",
 	specID = { SPEC_DRUID_BALANCE, SPEC_DRUID_FERAL, SPEC_DRUID_RESTO },

--- a/cooldowns_hunter.lua
+++ b/cooldowns_hunter.lua
@@ -75,7 +75,8 @@ LCT_SpellData[186265] = {
 LCT_SpellData[5384] = {
   class = "HUNTER",
   defensive = true,
-  cooldown = 30
+  cooldown = 30,
+  opt_lower_cooldown = 15 -- With "Craven Strategem" legendary
 }
 -- Spider Sting
 LCT_SpellData[202914] = {

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -198,7 +198,7 @@ LCT_SpellData[275773] = {
 LCT_SpellData[199448] = {
 	class = "PALADIN",
 	defensive = true,
-	duration = 12,
+	duration = 6,
 	cooldown = 120,
   replaces = 6940 -- normal Hand of Sacrifice
 }

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -197,7 +197,9 @@ LCT_SpellData[275773] = {
 -- Ultimate Sacrifice's Hand of Sacrifice
 LCT_SpellData[199448] = {
 	class = "PALADIN",
+	specID = { SPEC_PALADIN_HOLY },
 	defensive = true,
+	talent = true,
 	duration = 6,
 	cooldown = 120,
   replaces = 6940 -- normal Hand of Sacrifice

--- a/cooldowns_priest.lua
+++ b/cooldowns_priest.lua
@@ -75,7 +75,7 @@ LCT_SpellData[8122] = {
 	cooldown = 60,
 	opt_lower_cooldown = 30, -- Some holy priests don't spec into chastise stun, and keep the 60s cd on fear.
 	cooldown_overload = {
-		[SPEC_PRIEST_DISC] = 60, -- Most disc priests play with -30s talent, therefore make it baseline.
+		[SPEC_PRIEST_DISC] = 30, -- Most disc priests play with -30s talent, therefore make it baseline.
 	}
 }
 -- Priest/talents

--- a/cooldowns_priest.lua
+++ b/cooldowns_priest.lua
@@ -72,9 +72,10 @@ LCT_SpellData[32375] = {
 LCT_SpellData[8122] = {
 	class = "PRIEST",
 	cc = true,
-	cooldown = 30, -- Technically 60, but most priests play with -30s talent.
+	cooldown = 60,
+	opt_lower_cooldown = 30, -- Some holy priests don't spec into chastise stun, and keep the 60s cd on fear.
 	cooldown_overload = {
-		[SPEC_PRIEST_SHADOW] = 60, -- Shadow priest doesn't have the -30s talent
+		[SPEC_PRIEST_DISC] = 60, -- Most disc priests play with -30s talent, therefore make it baseline.
 	}
 }
 -- Priest/talents

--- a/cooldowns_priest.lua
+++ b/cooldowns_priest.lua
@@ -310,13 +310,6 @@ LCT_SpellData[213602] = {
 	cooldown = 45,
 	replaces = 586 -- Fade
 }
--- Inner Focus
-LCT_SpellData[196762] = {
-	class = "PRIEST",
-	specID = { SPEC_PRIEST_HOLY },
-	talent = true,
-	cooldown = 30
-}
 -- Ray of Hope
 LCT_SpellData[197268] = {
 	class = "PRIEST",
@@ -329,7 +322,6 @@ LCT_SpellData[197268] = {
 LCT_SpellData[34861] = {
 	class = "PRIEST",
 	specID = { SPEC_PRIEST_HOLY },
-	talent = true,
 	heal = true,
 	cooldown = 60
 }

--- a/cooldowns_warlock.lua
+++ b/cooldowns_warlock.lua
@@ -15,13 +15,13 @@ LCT_SpellData[20707] = {
 LCT_SpellData[212295] = {
 	class = "WARLOCK",
 	defensive = true,
-	duration = 5,
+	talent = true,
+	duration = 3,
 	cooldown = 45
 }
 -- Demonic Circle: Teleport
 LCT_SpellData[48020] = {
 	class = "WARLOCK",
-	talent = true,
 	defensive = true,
 	cooldown = 30
 }


### PR DESCRIPTION
- DK: add Apocalypse
- Druid: add Incapacitating Roar for other specs (due to Guardian Affinity)
- Hunter: Feign Death can be 15s cooldown due to legendary
- Paladin: Ultimate Sacrifice is now 6s duration after nerf
- Priest: Psychic Scream has 30s baseline for disc priest, other specs use 60s cooldown and 30s optional (a lot of holy priests spec into chastise stun and therefore 60s cooldown on fear)
- Warlock: Netherward is 3s duration and a talent (instead of baseline); Teleport is baseline (instead of talent)