### PR TITLE
Update for patch 9.1.5

### DIFF
--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -221,7 +221,8 @@ LCT_SpellData[47568] = {
 	class = "DEATHKNIGHT",
 	specID = { SPEC_DK_FROST },
 	offensive = true,
-	cooldown = 120
+	duration = 20,
+	cooldown = 105
 }
 -- Remorseless Winter
 LCT_SpellData[196770] = {
@@ -277,6 +278,7 @@ LCT_SpellData[305392] = {
 	class = "DEATHKNIGHT",	
 	specID = { SPEC_DK_FROST },	
 	talent = true,	
+	duration = 4,
 	cooldown = 45	
 }
 

--- a/cooldowns_demonhunter.lua
+++ b/cooldowns_demonhunter.lua
@@ -306,6 +306,6 @@ LCT_SpellData[323639] = {
 	class = "DEMONHUNTER",
 	covenant = "NIGHTFAE",
 	offensive = true,
-	duration = 2,
+	duration = 5,
 	cooldown = 90
 }

--- a/cooldowns_demonhunter.lua
+++ b/cooldowns_demonhunter.lua
@@ -306,6 +306,6 @@ LCT_SpellData[323639] = {
 	class = "DEMONHUNTER",
 	covenant = "NIGHTFAE",
 	offensive = true,
-	duration = 5,
+	duration = 6,
 	cooldown = 90
 }

--- a/cooldowns_druid.lua
+++ b/cooldowns_druid.lua
@@ -436,5 +436,6 @@ LCT_SpellData[323764] = {
 	covenant = "NIGHTFAE",
 	offensive = true,
 	duration = 4,
-	cooldown = 120
+	cooldown = 120,
+	opt_lower_cooldown = 60, -- Legendary
 }

--- a/cooldowns_hunter.lua
+++ b/cooldowns_hunter.lua
@@ -4,6 +4,14 @@ local SPEC_HUNTER_BM   = 253
 local SPEC_HUNTER_MM   = 254
 local SPEC_HUNTER_SURV = 255
 
+local bestial_wrath = { spellid = 19574, duration = 12 } -- Bestial Wrath cooldown reduction
+
+-- Barbed Shot
+LCT_SpellData[217200] = {
+  class = "HUNTER",
+  reduce = bestial_wrath
+}
+
 -- Specs:
 -- 253 BM
 -- 254 MM
@@ -192,7 +200,7 @@ LCT_SpellData[19574] = {
 	class = "HUNTER",
 	specID = { SPEC_HUNTER_BM },
 	offensive = true,
-	duration = 10,
+	duration = 15,
 	cooldown = 90
 }
 -- Aspect of the wild

--- a/cooldowns_monk.lua
+++ b/cooldowns_monk.lua
@@ -265,6 +265,7 @@ LCT_SpellData[137639] = {
 	specID = { SPEC_MONK_WINDWALKER },
 	offensive = true,
 	charges = 2,
+	duration = 15,
 	cooldown = 90,
 }
 -- Energizing Elixir
@@ -315,7 +316,7 @@ LCT_SpellData[261715] = {
 LCT_SpellData[123904] = {
 	class = "MONK",
 	specID = { SPEC_MONK_WINDWALKER },
-	duration = 20,
+	duration = 24,
 	cooldown = 120,
 }
 -- Mond/Windwalker/talents

--- a/cooldowns_paladin.lua
+++ b/cooldowns_paladin.lua
@@ -436,6 +436,7 @@ LCT_SpellData[343721] = {
 	class = "PALADIN",
 	specID = { SPEC_PALADIN_RETRIBUTION },
 	talent = true,
+	duration = 8,
 	cooldown = 60
 }
 

--- a/cooldowns_rogue.lua
+++ b/cooldowns_rogue.lua
@@ -308,7 +308,7 @@ LCT_SpellData[323654] = {
 	class = "ROGUE",
 	covenant = "VENTHYR",
 	offensive = true,
-	duration = 20,
+	duration = 12,
 	cooldown = 90
 }
 

--- a/cooldowns_rogue.lua
+++ b/cooldowns_rogue.lua
@@ -258,8 +258,9 @@ LCT_SpellData[121471] = {
 	class = "ROGUE",
 	specID = { SPEC_ROGUE_SUB },
 	offensive = true,
-	duration = 15,
+	duration = 20,
 	cooldown = 180,
+	opt_lower_cooldown = 120, -- Thief's Bargain
 }
 -- Rogue/Subtetly/talents
 -- Cold Blood

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -121,7 +121,7 @@ LCT_SpellData[320125] = {
 	class = "SHAMAN",
 	specID = { SPEC_SHAMAN_ELEMENTAL },
 	talent = true,
-	duration = 2, -- Most likely used right before a damage spell, put 2sec duration for highlight
+	duration = 3, -- Most likely used right before a damage spell, put 3s duration for highlight
 	cooldown = 30,
 }
 -- Stormkeeper

--- a/cooldowns_shaman.lua
+++ b/cooldowns_shaman.lua
@@ -121,6 +121,7 @@ LCT_SpellData[320125] = {
 	class = "SHAMAN",
 	specID = { SPEC_SHAMAN_ELEMENTAL },
 	talent = true,
+	duration = 2, -- Most likely used right before a damage spell, put 2sec duration for highlight
 	cooldown = 30,
 }
 -- Stormkeeper

--- a/cooldowns_warrior.lua
+++ b/cooldowns_warrior.lua
@@ -145,6 +145,7 @@ LCT_SpellData[118038] = {
 LCT_SpellData[167105] = {
 	class = "WARRIOR",
 	specID = { SPEC_WARRIOR_ARMS },
+	duration = 10,
 	cooldown = 45,
 }
 -- Sweeping Strikes
@@ -161,6 +162,7 @@ LCT_SpellData[262161] = {
 	class = "WARRIOR",
 	specID = { SPEC_WARRIOR_ARMS },
 	talent = true,
+	duration = 10,
 	cooldown = 45,
 	replaces = 167105, -- Colossus Smash
 }


### PR DESCRIPTION
Updated the following abilities after playing some arena in 9.1.5

DK:
- Empower Rune Weapon: add duration 20s, cooldown is 105s with rank 2 passive
- Chill Streak: add duration 4s

DH:
- The Hunt: update duration to 6s (dot duration)

Druid:
- Convoke the Spirits: add opt lower cooldown 1min (with legendary)

Hunter:
- Add cooldown reduction of Bestial Wrath when using Barbed Shot
- Bestial Wrath: update duration to 15s

Monk:
- Storm, Earth and Fire: duration should be 15s
- Xuen: duration should be 24s

Paladin:
- Final Reckoning: add duration 8s

Rogue:
- Shadow Blades: update duration, add opt lower cooldown due to PVP talent
- Flagellation: duration is 12s

Shaman:
- Echoing Shock: add duration 3s since it's most likely pressed right before a damage spell

Warrior:
- Colossal Smash: add duration 10s 