### PR TITLE
Adds Dracthyr race, Devastation and Preservation spells

### DIFF
--- a/cooldowns_evoker.lua
+++ b/cooldowns_evoker.lua
@@ -7,7 +7,9 @@ local SPEC_EVOKER_PRESERVATION = 1468
 -- Fire Breath
 LCT_SpellData[357208] = {
   class = "EVOKER",
-  cooldown = 30
+  cooldown = 30,
+  -- TODO: Fire Breath's CD is reduced when consuming essence bursts when
+  --       talented into 'Feed the Flames'
 }
 
 -- Blessing of the Bronze
@@ -19,7 +21,8 @@ LCT_SpellData[364342] = {
 -- Hover
 LCT_SpellData[358267] = {
   class = "EVOKER",
-  cooldown = 35
+  cooldown = 35,
+  opt_charges = 2 -- Hover gets two charges with the 'Aerial Mastery' talent
 }
 
 -- Living Flame
@@ -31,7 +34,8 @@ LCT_SpellData[361469] = {
 -- Deep Breath
 LCT_SpellData[357210] = {
   class = "EVOKER",
-  cooldown = 120
+  cooldown = 120,
+  opt_lower_cooldown = 60 -- Reduced by the 'Onyx Legacy' talent
 }
 
 -- Fury of the Aspects
@@ -69,15 +73,18 @@ LCT_SpellData[363916] = {
   talent = true,
   duration = 12,
   cooldown = 150,
-  defensive = true
+  defensive = true,
+  opt_charges = 2 -- With the Obsidian Bulwalk talent
 }
 
--- Opressing Roar
+-- Oppressing Roar
 LCT_SpellData[372048] = {
   class = "EVOKER",
   talent = true,
   cooldown = 120,
   duration = 10
+  -- TODO: Oppressing Roar's cooldown can be reduced when talented into 'Overawe'
+  --       which reduces the CD by 20s/Enrage removed.
 }
 
 -- Sleep Walk
@@ -118,7 +125,8 @@ LCT_SpellData[374251] = {
 LCT_SpellData[358385] = {
   class = "EVOKER",
   talent = true,
-  cooldown = 150
+  cooldown = 150,
+  opt_lower_cooldown = 120 -- Reduced by the 'Forger of Mountains' talent
 }
 
 -- Quell
@@ -127,6 +135,7 @@ LCT_SpellData[351338] = {
   talent = true,
   cooldown = 40,
   interrupt = true,
+  opt_lower_cooldown = 20 -- Reduced by the 'Imposing Presence' talent
 }
 
 -- Renewing Blaze
@@ -136,7 +145,8 @@ LCT_SpellData[374348] = {
   cooldown = 150,
   duration = 8,
   heal = true,
-  defensive = true
+  defensive = true,
+  opt_lower_cooldown = 120 -- Reduced by the 'Fire Within' talent
 }
 
 -- Rescue
@@ -281,6 +291,7 @@ LCT_SpellData[367226] = {
   talent = true,
   cooldown = 30,
   heal = true,
+  opt_lower_cooldown = 20 -- Reduced by the 'Spiritual Clarity' talent
 }
 
 -- Rewind
@@ -290,6 +301,7 @@ LCT_SpellData[363534] = {
   talent = true,
   cooldown = 240,
   heal = true,
+  opt_lower_cooldown = 180 -- Reduced by the 'Temporal Artificer' talent
 }
 
 -- Stasis
@@ -306,6 +318,7 @@ LCT_SpellData[366155] = {
   specID = { SPEC_EVOKER_PRESERVATION },
   talent = true,
   cooldown = 9,
+  opt_charges = 2, -- Charges added with the 'Punctuality' talent
   heal = true
 }
 

--- a/cooldowns_evoker.lua
+++ b/cooldowns_evoker.lua
@@ -44,26 +44,11 @@ LCT_SpellData[390386] = {
   cooldown = 300
 }
 
--- Disintegrate
-LCT_SpellData[356995] = {
-  class = "EVOKER"
-}
-
--- Azure Strike
-LCT_SpellData[362969] = {
-  class = "EVOKER"
-}
-
 -- Emerald Blossom
 LCT_SpellData[355913] = {
   class = "EVOKER",
   cooldown = 30,
   heal = true,
-}
-
--- Return
-LCT_SpellData[361227] = {
-  class = "EVOKER"
 }
 
 -- Evoker Talents
@@ -199,12 +184,6 @@ LCT_SpellData[360823] = {
   cooldown_starts_on_dispel = true
 }
 
--- Mass Return
-LCT_SpellData[361178] = {
-  class = "EVOKER",
-  specID = { SPEC_EVOKER_PRESERVATION }
-}
-
 -- Devastation Talents
 -- Dragonrage
 LCT_SpellData[375087] = {
@@ -232,13 +211,6 @@ LCT_SpellData[370452] = {
   cooldown = 15
 }
 
--- Pyre
-LCT_SpellData[357211] = {
-  class = "EVOKER",
-  specID = { SPEC_EVOKER_DEVASTATION },
-  talent = true
-}
-
 -- Firestorm
 LCT_SpellData[368847] = {
   class = "EVOKER",
@@ -248,14 +220,6 @@ LCT_SpellData[368847] = {
 }
 
 -- Preservation Talents
--- Echo
-LCT_SpellData[364343] = {
-  class = "EVOKER",
-  specID = { SPEC_EVOKER_PRESERVATION },
-  talent = true,
-  heal = true,
-}
-
 -- Dream Breath
 LCT_SpellData[355936] = {
   class = "EVOKER",

--- a/cooldowns_evoker.lua
+++ b/cooldowns_evoker.lua
@@ -6,8 +6,8 @@ local SPEC_EVOKER_PRESERVATION = 1468
 -- Evoker/Baseline
 -- Fire Breath
 LCT_SpellData[357208] = {
-	class = "EVOKER",
-	cooldown = 30
+  class = "EVOKER",
+  cooldown = 30
 }
 
 -- Blessing of the Bronze
@@ -101,7 +101,7 @@ LCT_SpellData[365585] = {
   talent = true,
   cooldown = 8,
   dispel = true,
-	cooldown_starts_on_dispel = true
+  cooldown_starts_on_dispel = true
 }
 
 -- Cauterizing Flame
@@ -110,7 +110,7 @@ LCT_SpellData[374251] = {
   talent = true,
   cooldown = 60,
   dispel = true,
-	cooldown_starts_on_dispel = true,
+  cooldown_starts_on_dispel = true,
   heal = true,
 }
 
@@ -162,7 +162,7 @@ LCT_SpellData[370553] = {
 }
 
 -- Time Spiral
-LCT_SpellData[374698] = {
+LCT_SpellData[374968] = {
   class = "EVOKER",
   talent = true,
   cooldown = 120
@@ -186,7 +186,7 @@ LCT_SpellData[360823] = {
   talent = true,
   cooldown = 8,
   dispel = true,
-	cooldown_starts_on_dispel = true
+  cooldown_starts_on_dispel = true
 }
 
 -- Mass Return
@@ -319,7 +319,7 @@ LCT_SpellData[359816] = {
 }
 
 -- Emerald Communion
-LCT_SpellData[370060] = {
+LCT_SpellData[370960] = {
   class = "EVOKER",
   specID = { SPEC_EVOKER_PRESERVATION },
   talent = true,
@@ -370,8 +370,8 @@ LCT_SpellData[377509] = {
 -- Covenant Abilities
 -- Boon of the Covenants
 LCT_SpellData[387168] = {
-	class = "EVOKER",
-	offensive = true,
-	duration = 12,
-	cooldown = 120
+  class = "EVOKER",
+  offensive = true,
+  duration = 12,
+  cooldown = 120
 }

--- a/cooldowns_evoker.lua
+++ b/cooldowns_evoker.lua
@@ -1,0 +1,377 @@
+-- ================ EVOKER ================
+
+local SPEC_EVOKER_DEVASTATION = 1467
+local SPEC_EVOKER_PRESERVATION = 1468
+
+-- Evoker/Baseline
+-- Fire Breath
+LCT_SpellData[357208] = {
+	class = "EVOKER",
+	cooldown = 30
+}
+
+-- Blessing of the Bronze
+LCT_SpellData[364342] = {
+  class = "EVOKER",
+  cooldown = 15
+}
+
+-- Hover
+LCT_SpellData[358267] = {
+  class = "EVOKER",
+  cooldown = 35
+}
+
+-- Living Flame
+LCT_SpellData[361469] = {
+  class = "EVOKER",
+  heal = true,
+}
+
+-- Deep Breath
+LCT_SpellData[357210] = {
+  class = "EVOKER",
+  cooldown = 120
+}
+
+-- Fury of the Aspects
+LCT_SpellData[390386] = {
+  class = "EVOKER",
+  cooldown = 300
+}
+
+-- Disintegrate
+LCT_SpellData[356995] = {
+  class = "EVOKER"
+}
+
+-- Azure Strike
+LCT_SpellData[362969] = {
+  class = "EVOKER"
+}
+
+-- Emerald Blossom
+LCT_SpellData[355913] = {
+  class = "EVOKER",
+  cooldown = 30,
+  heal = true,
+}
+
+-- Return
+LCT_SpellData[361227] = {
+  class = "EVOKER"
+}
+
+-- Evoker Talents
+-- Obsidian Scales
+LCT_SpellData[363916] = {
+  class = "EVOKER",
+  talent = true,
+  duration = 12,
+  cooldown = 150,
+  defensive = true
+}
+
+-- Opressing Roar
+LCT_SpellData[372048] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 120,
+  duration = 10
+}
+
+-- Sleep Walk
+LCT_SpellData[360806] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 15,
+  cc = true,
+}
+
+-- Unravel
+LCT_SpellData[368432] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 9
+}
+
+-- Expunge
+LCT_SpellData[365585] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 8,
+  dispel = true,
+	cooldown_starts_on_dispel = true
+}
+
+-- Cauterizing Flame
+LCT_SpellData[374251] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 60,
+  dispel = true,
+	cooldown_starts_on_dispel = true,
+  heal = true,
+}
+
+-- Landslide
+LCT_SpellData[358385] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 150
+}
+
+-- Quell
+LCT_SpellData[351338] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 40,
+  interrupt = true,
+}
+
+-- Renewing Blaze
+LCT_SpellData[374348] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 150,
+  duration = 8,
+  heal = true,
+  defensive = true
+}
+
+-- Rescue
+LCT_SpellData[370665] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 60
+}
+
+-- Verdant Embrace
+LCT_SpellData[360995] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 24,
+  heal = true
+}
+
+-- Tip the Scales
+LCT_SpellData[370553] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 120
+}
+
+-- Time Spiral
+LCT_SpellData[374698] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 120
+}
+
+-- Zephyr
+LCT_SpellData[374227] = {
+  class = "EVOKER",
+  talent = true,
+  duration = 8,
+  cooldown = 120
+}
+
+-- Preservation Specific Abilities
+-- Renewing Breath
+
+-- Naturalize
+LCT_SpellData[360823] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 8,
+  dispel = true,
+	cooldown_starts_on_dispel = true
+}
+
+-- Mass Return
+LCT_SpellData[361178] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION }
+}
+
+-- Devastation Talents
+-- Dragonrage
+LCT_SpellData[375087] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_DEVASTATION },
+  talent = true,
+  offensive = true,
+  cooldown = 120
+}
+
+-- Eternity Surge
+LCT_SpellData[359073] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_DEVASTATION },
+  talent = true,
+  cooldown = 30
+}
+
+-- Shattering Star
+LCT_SpellData[370452] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_DEVASTATION },
+  talent = true,
+  offensive = true,
+  cooldown = 15
+}
+
+-- Pyre
+LCT_SpellData[357211] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_DEVASTATION },
+  talent = true
+}
+
+-- Firestorm
+LCT_SpellData[368847] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_DEVASTATION },
+  talent = true,
+  cooldown = 20
+}
+
+-- Preservation Talents
+-- Echo
+LCT_SpellData[364343] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  heal = true,
+}
+
+-- Dream Breath
+LCT_SpellData[355936] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 35,
+  heal = true,
+}
+
+-- Temporal Anomaly
+LCT_SpellData[373861] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  duration = 6,
+  cooldown = 6,
+  heal = true,
+}
+
+-- Time Dilation
+LCT_SpellData[357170] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 60,
+  duration = 8,
+}
+
+-- Spiritbloom
+LCT_SpellData[367226] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 30,
+  heal = true,
+}
+
+-- Rewind
+LCT_SpellData[363534] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 240,
+  heal = true,
+}
+
+-- Stasis
+LCT_SpellData[370537] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 150
+}
+
+-- Reversion
+LCT_SpellData[366155] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 9,
+  heal = true
+}
+
+-- Dream Flight
+LCT_SpellData[359816] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 120,
+  heal = true
+}
+
+-- Emerald Communion
+LCT_SpellData[370060] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 180,
+  heal = true
+}
+
+-- Devastation PvP Talents
+-- Nullifying Shroud
+LCT_SpellData[378464] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 150
+}
+
+-- Chrono Loop
+LCT_SpellData[383005] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 150
+}
+
+-- Time Stop
+LCT_SpellData[378441] = {
+  class = "EVOKER",
+  talent = true,
+  duration = 4,
+  cooldown = 120,
+  defensive = true
+}
+
+-- Swoop Up
+LCT_SpellData[370388] = {
+  class = "EVOKER",
+  talent = true,
+  cooldown = 150
+}
+
+-- Preservation PvP Talents
+-- Dream Projection
+LCT_SpellData[377509] = {
+  class = "EVOKER",
+  specID = { SPEC_EVOKER_PRESERVATION },
+  talent = true,
+  cooldown = 150
+}
+
+-- Covenant Abilities
+-- Boon of the Covenants
+LCT_SpellData[387168] = {
+	class = "EVOKER",
+	offensive = true,
+	duration = 12,
+	cooldown = 120
+}

--- a/cooldowns_racials.lua
+++ b/cooldowns_racials.lua
@@ -155,3 +155,15 @@ LCT_SpellData[265221] = {
 	race = "DarkIronDwarf",
 	cooldown = 120,
 }
+-- Wing Buffet (Dracthyr)
+LCT_SpellData[357214] = {
+	race = "Dracthyr",
+	cooldown = 72,
+	opt_lower_cooldown = 27 -- Reduced by the 'Heavy Wingbeats' talent
+}
+-- Tail Swipe (Dracthyr)
+LCT_SpellData[368970] = {
+	race = "Dracthyr",
+	cooldown = 72,
+	opt_lower_cooldown = 27 -- Reduced by the 'Clobbering Sweep' talent
+}

--- a/lib.xml
+++ b/lib.xml
@@ -8,6 +8,7 @@
 	<Script file="cooldowns_deathknight.lua"/>
 	<Script file="cooldowns_demonhunter.lua"/>
 	<Script file="cooldowns_druid.lua"/>
+	<Script file="cooldowns_evoker.lua"/>
 	<Script file="cooldowns_hunter.lua"/>
 	<Script file="cooldowns_mage.lua"/>
 	<Script file="cooldowns_monk.lua"/>

--- a/specs.lua
+++ b/specs.lua
@@ -119,7 +119,15 @@ function lib:GetSpecializationInfoByID(specID)
 			name = "Restoration",
 			icon = 136052,
 		},
-		
+		-- evoker
+		[1467] = {
+			name = "Devastation",
+			icon = 4511811
+		},
+		[1468] = {
+			name = "Preservation",
+			icon = 4511812
+		}
 	}
 	return specs[specID].name, specs[specID].icon
 end


### PR DESCRIPTION
# What this does
Adds the library of new abilities for Evoker added in the 10.0 pre-patch.

_Disclaimer:_ I mainly used Wowhead for the CD times and caught a few mistakes already. I believe I caught them all but a second set of eyes would be good.

## Testing Done
- Copied it directly into my version of GladiusEX and seems to be mostly okay. The only issue I've noticed is that the Dracthyr icon (under racials) does not show up.
