### PR TITLE
WotLK bug fixes

### DIFF
--- a/cooldowns_wrath_druid.lua
+++ b/cooldowns_wrath_druid.lua
@@ -35,8 +35,6 @@ LCT_SpellData[33831] = {
 LCT_SpellData[16689] = {
   cooldown = 60,
   class = "DRUID",
-  talent = true,
-  specID = { SPEC_DRUID_BALANCE },
 }
 LCT_SpellData[16810] = 16689
 LCT_SpellData[16811] = 16689

--- a/cooldowns_wrath_mage.lua
+++ b/cooldowns_wrath_mage.lua
@@ -197,6 +197,7 @@ LCT_SpellData[11426] = {
   opt_lower_cooldown = 24,
   class = "MAGE",
   talent = true,
+  specID = { SPEC_MAGE_FROST },
   detects = { 11958 }
 }
 LCT_SpellData[13031] = 11426

--- a/cooldowns_wrath_rogue.lua
+++ b/cooldowns_wrath_rogue.lua
@@ -1,7 +1,7 @@
 -- ================ ROGUE ================
 
 local SPEC_ROGUE_ASSA = 259
-local SPEC_ROGUE_OUTLAW = 260
+local SPEC_ROGUE_COMBAT = 260
 local SPEC_ROGUE_SUB = 261
 
 -- Blind
@@ -99,12 +99,13 @@ LCT_SpellData[14278] = {
   cooldown = 20,
   class = "ROGUE",
   talent = true,
+  specID = { SPEC_ROGUE_SUB },
 }
 
 -- Stealth
 LCT_SpellData[1784] = {
   class = "ROGUE",
-  opt_lower_cooldown = 5,
+  opt_lower_cooldown = 8, -- Camouflage talent
   cooldown_starts_on_aura_fade = true,
   cooldown = 10,
 }
@@ -118,7 +119,7 @@ LCT_SpellData[13750] = {
 }
 
 -- Premeditation
--- XXX Cannot track this as it's only in stealth...
+-- Cannot track this as it's only in stealth...
 --LCT_SpellData[14183] = {
 --  cooldown = 120,
 --  class = "ROGUE",

--- a/cooldowns_wrath_warrior.lua
+++ b/cooldowns_wrath_warrior.lua
@@ -10,6 +10,7 @@ LCT_SpellData[12292] = {
   cooldown = 180,
   talent = true,
   duration = 30,
+  specID = { SPEC_WARRIOR_FURY },
 }
 
 -- Shield Block
@@ -38,7 +39,7 @@ LCT_SpellData[23881] = {
   class = "WARRIOR",
   cooldown = 4,
   talent = true,
-  detects = { 12292 },
+  specID = { SPEC_WARRIOR_FURY },
 }
 
 -- Intervene
@@ -128,7 +129,6 @@ LCT_SpellData[18499] = {
 LCT_SpellData[676] = {
   class = "WARRIOR",
   cooldown = 60,
-  talent = true,
 }
 
 -- Revenge


### PR DESCRIPTION
- Categorized some uncategorized talents into their correct specs
- Fixed the Combat spec (the variable was named "OUTLAW" by mistake)
- Changed TBC talents into baseline abilities (e.g., Nature's Grasp)