### PR TITLE
Minor WotLK updates/fixes

### DIFF
--- a/cooldowns_wrath_mage.lua
+++ b/cooldowns_wrath_mage.lua
@@ -212,6 +212,7 @@ LCT_SpellData[43039] = 11426
 LCT_SpellData[31687] = {
   cooldown = 180,
   class = "MAGE",
+  talent = true,
   specID = { SPEC_MAGE_FROST },
 }
 

--- a/cooldowns_wrath_racials.lua
+++ b/cooldowns_wrath_racials.lua
@@ -11,9 +11,14 @@ LCT_SpellData[28880] = {
 LCT_SpellData[7744] = {
 	race = "Scourge",
 	cooldown = 120,
-  -- TODO sets cd of trinket
+    sets_cooldowns = {
+        -- PvP Trinket
+		{ spellid = 42292, cooldown = 45 },
+        -- Will to Survive 
+        { spellid = 59752, cooldown = 45 },
+    },
 }
--- Will to Survive (Human)
+-- Will to Survive / EMFH (Human)
 LCT_SpellData[59752] = {
     race = "Human",
     cooldown = 120,

--- a/cooldowns_wrath_warrior.lua
+++ b/cooldowns_wrath_warrior.lua
@@ -39,6 +39,7 @@ LCT_SpellData[23881] = {
   class = "WARRIOR",
   cooldown = 4,
   talent = true,
+  detects = { 12292 },
   specID = { SPEC_WARRIOR_FURY },
 }
 


### PR DESCRIPTION
- Water Elemental is now correctly considered a talent
- Bloodthirst now detects Death Wish for Fury Warriors (mandatory pick)
- Will of the Forsaken and trinket+EMFH now all share CD