### PR TITLE
Fixed bug with sets_cooldown vs sets_cooldowns

### DIFF
--- a/cooldowns_cata_items.lua
+++ b/cooldowns_cata_items.lua
@@ -5,9 +5,9 @@ LCT_SpellData[42292] = {
 	cooldown = 120,
 	icon_alliance = [[Interface\Icons\INV_Jewelry_TrinketPVP_01]],
 	icon_horde = [[Interface\Icons\INV_Jewelry_TrinketPVP_01]],
-    icon_horde_wotlk = [[Interface\Icons\inv_jewelry_necklace_38]],
-    icon_alliance_wotlk = [[Interface\Icons\inv_jewelry_necklace_37]],
-	sets_cooldown = {
+	icon_horde_wotlk = [[Interface\Icons\inv_jewelry_necklace_38]],
+	icon_alliance_wotlk = [[Interface\Icons\inv_jewelry_necklace_37]],
+	sets_cooldowns = {
 		-- WOTF
 		{ spellid = 7744, cooldown = 30 },
         -- Will to Survive (EMFH)

--- a/cooldowns_cata_racials.lua
+++ b/cooldowns_cata_racials.lua
@@ -11,7 +11,7 @@ LCT_SpellData[59547] = {
 LCT_SpellData[7744] = {
 	race = "Scourge",
 	cooldown = 120,
-    sets_cooldown = {
+    sets_cooldowns = {
         -- PvP Trinket
         { spellid = 42292, cooldown = 30 },
         -- Every Man for Himself
@@ -22,7 +22,7 @@ LCT_SpellData[7744] = {
 LCT_SpellData[59752] = {
     race = "Human",
     cooldown = 120,
-    sets_cooldown = {
+    sets_cooldowns = {
         -- WOTF
         { spellid = 7744, cooldown = 30 },
         -- PvP Trinkets

--- a/library.lua
+++ b/library.lua
@@ -484,7 +484,7 @@ local function CooldownEvent(event, unit, spellid)
         end
 
         -- V: set other cooldown(s)
-        local sets_cooldowns = spelldata.sets_cooldown or spelldata.sets_cooldown and { spelldata.sets_cooldown } or {}
+        local sets_cooldowns = spelldata.sets_cooldowns or spelldata.sets_cooldown and { spelldata.sets_cooldown } or {}
 
         for i = 1, #sets_cooldowns do
           local cd = sets_cooldowns[i]


### PR DESCRIPTION
Caused issues with shared CDs and (primarily) trinkets not showing CDs properly.