### PR TITLE
update lib to work on TWW pre-patch

### DIFF
--- a/cooldowns_deathknight.lua
+++ b/cooldowns_deathknight.lua
@@ -52,7 +52,7 @@ LCT_SpellData[48792] = {
 	_talent = true,
 	defensive = true,
 	duration = 8,
-	cooldown = 180,
+	cooldown = 120,
 	opt_lower_cooldown = 148, -- ?
 }
 -- Anti-Magic Shell

--- a/cooldowns_hunter.lua
+++ b/cooldowns_hunter.lua
@@ -60,7 +60,7 @@ LCT_SpellData[109304] = {
 LCT_SpellData[187650] = {
 	class = "HUNTER",
 	cc = true,
-	cooldown = 30
+	cooldown = 25
 }
 -- Aspect of Turtle
 LCT_SpellData[186265] = {

--- a/cooldowns_monk.lua
+++ b/cooldowns_monk.lua
@@ -305,16 +305,6 @@ LCT_SpellData[261947] = {
 	talent = true,
 	cooldown = 30,
 }
--- Serenity
-LCT_SpellData[152173] = {
-	class = "MONK",
-	specID = { SPEC_MONK_WINDWALKER },
-	talent = true,
-	offensive = true,
-	duration = 8,
-	cooldown = 90,
-	replaces = 137639 -- Storm, Earth, and Fire
-}
 
 -- Monk/Mistweaver
 -- Detox
@@ -324,12 +314,6 @@ LCT_SpellData[115450] = {
 	dispel = true,
 	cooldown_starts_on_dispel = true,
 	cooldown = 8,
-}
--- Essence Font
-LCT_SpellData[191837] = {
-	class = "MONK",
-	specID = { SPEC_MONK_MISTWEAVER },
-	cooldown = 12,
 }
 -- Life Cocoon
 LCT_SpellData[116849] = {

--- a/cooldowns_warrior.lua
+++ b/cooldowns_warrior.lua
@@ -99,11 +99,25 @@ LCT_SpellData[236077] = {
 -- Dragon Roar
 LCT_SpellData[118000] = {
 	class = "WARRIOR",
-	specID = { SPEC_WARRIOR_FURY, SPEC_WARRIOR_PROT },
 	talent = true,
 	knockback = true,
 	duration = 6,
 	cooldown = 35,
+}
+-- Ravager
+LCT_SpellData[228920] = {
+	class = "WARRIOR",
+	specID = { SPEC_WARRIOR_FURY, SPEC_WARRIOR_ARMS },
+	talent = true,
+	cooldown = 90
+}
+-- Bladestorm
+LCT_SpellData[46924] = {
+	class = "WARRIOR",
+	specID = { SPEC_WARRIOR_FURY, SPEC_WARRIOR_ARMS },
+	talent = true,
+	offensive = true,
+	cooldown = 90
 }
 
 -- Warrior/Arms
@@ -113,12 +127,6 @@ LCT_SpellData[7384] = {
 	specID = { SPEC_WARRIOR_ARMS },
 	cooldown = 12,
 	opt_charges = 3,
-}
--- Bladestorm
-LCT_SpellData[227847] = {
-	class = "WARRIOR",
-	specID = { SPEC_WARRIOR_ARMS },
-	cooldown = 90
 }
 -- Mortal Strike
 LCT_SpellData[12294] = {
@@ -160,15 +168,6 @@ LCT_SpellData[262161] = {
 	cooldown = 45,
 	replaces = 167105, -- Colossus Smash
 }
--- Ravager
-LCT_SpellData[152277] = {
-	class = "WARRIOR",
-	specID = { SPEC_WARRIOR_ARMS },
-	talent = true,
-	cooldown = 45,
-	duration = 7,
-	replaces = 227847 -- Bladestorm
-}
 -- Cleave
 LCT_SpellData[845] = {
 	class ="WARRIOR",
@@ -201,9 +200,9 @@ LCT_SpellData[262228] = {
 	cooldown = 60
 }
 -- Defensive Stance
-LCT_SpellData[197690] = {
+LCT_SpellData[386208] = {
 	class = "WARRIOR",
-	specID = { SPEC_WARRIOR_ARMS },
+	specID = { SPEC_WARRIOR_ARMS, SPEC_WARRIOR_FURY },
 	defensive = true,
 	talent = true,
 	cooldown = 3
@@ -262,15 +261,6 @@ LCT_SpellData[280772] = {
 	specID = { SPEC_WARRIOR_FURY },
 	talent = true,
 	cooldown = 30,
-}
--- Bladestorm
-LCT_SpellData[46924] = {
-	class = "WARRIOR",
-	specID = { SPEC_WARRIOR_FURY },
-	talent = true,
-	offensive = true,
-	duration = 6,
-	cooldown = 60
 }
 
 -- Warrior/Protection

--- a/cooldowns_warrior.lua
+++ b/cooldowns_warrior.lua
@@ -99,6 +99,7 @@ LCT_SpellData[236077] = {
 -- Dragon Roar
 LCT_SpellData[118000] = {
 	class = "WARRIOR",
+	specID = { SPEC_WARRIOR_FURY, SPEC_WARRIOR_PROT },
 	talent = true,
 	knockback = true,
 	duration = 6,


### PR DESCRIPTION
Hello,
here are some tweaks to remove non-existing abilities and update cooldown timers for couple of abilities. Additionaly after this merge it requires another changes in GladiusEx repo (pull request will be created after this one).

**cooldowns_deathknight.lua**
_IceBound Fortitude_ 2 min CD - (was 3 min)

**cooldowns_hunter.lua**
_Freezing Trap_ 25s CD - (was 30) ---> all of the hunters in pvp pick talent to reduce their freezing trap by 5 sec

**cooldowns_monk.lua**
_Serenity_ and _Essence font_ are completely gone

**cooldowns_warrior.lua**
_Ravager_ and _Bladestorm_ are now available to Fury/Arms on 1.5m CD (ravager got new spell ID)
_Defensive stance_ is now available to Fury. New spell ID for both (arms/fury)

I am willing to go through whole retail cooldowns DB and update it for TWW. Hit me up on discord if interested (name: krionel) 