### PR TITLE
Attempt to fix Nature's Swiftness and Presence of Mind

### DIFF
--- a/cooldowns_mists_druid.lua
+++ b/cooldowns_mists_druid.lua
@@ -269,7 +269,7 @@ LCT_SpellData[102342] = {
 	specID = { 105 },
 	defensive = true,
 	duration = 12,
-	cooldown = 60
+	cooldown = 30 -- Not 60, cuz 4 pieces PvP set bonus for rdru reduce cd by 30 sec
 }
 -- Nature's Cure
 LCT_SpellData[88423] = {

--- a/cooldowns_mists_druid.lua
+++ b/cooldowns_mists_druid.lua
@@ -250,7 +250,7 @@ LCT_SpellData[61336] = {
 -- Nature's Swiftness
 LCT_SpellData[132158] = {
 	class = "DRUID",
-	specID = { 105 },
+	specID = { 102, 105 },
 	heal = true,
 	cooldown_starts_on_aura_fade = true,
 	cooldown = 60

--- a/cooldowns_mists_mage.lua
+++ b/cooldowns_mists_mage.lua
@@ -94,6 +94,14 @@ LCT_SpellData[108843] = {
 	duration = 1.5,
 	cooldown = 25
 }
+-- Presence of Mind
+LCT_SpellData[12043] = {
+	class = "MAGE",
+	specID = { 62 },
+	offensive = true,
+	cooldown_starts_on_aura_fade = true,
+	cooldown = 90
+}
 -- Cauterize
 LCT_SpellData[86949] = {
 	class = "MAGE",
@@ -174,14 +182,6 @@ LCT_SpellData[115610] = {
 	cooldown = 25
 }
 -- Mage/Arcane
--- Presence of Mind
-LCT_SpellData[12043] = {
-	class = "MAGE",
-	specID = { 62 },
-	offensive = true,
-	cooldown_starts_on_aura_fade = true,
-	cooldown = 90
-}
 -- Arcane Power
 LCT_SpellData[12042] = {
 	class = "MAGE",


### PR DESCRIPTION
I would like to start from the point that I need some help, so affected areas are:
1. Nature's Swiftness now appears for Balance spec <img width="892" height="144" alt="image" src="https://github.com/user-attachments/assets/ccbb9135-8f31-4513-a066-1532a8b9513e" />
2. But Presence of Mind isn't in talent section, and other talents are also not present, except of two <img width="927" height="444" alt="image" src="https://github.com/user-attachments/assets/761bd017-c89f-446d-be8b-0568543d0ca4" />
3. Nature's Swiftness is NOT on track when druid presses it for some reason

I need advice how can I troubleshoot these issues? Every help is very appreciated!